### PR TITLE
Add Moby-Duck as an evolving item

### DIFF
--- a/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/EvolvingItemAdder.java
+++ b/src/main/java/de/hysky/skyblocker/skyblock/item/slottext/adders/EvolvingItemAdder.java
@@ -27,7 +27,7 @@ public class EvolvingItemAdder extends SimpleSlotTextAdder {
 	@Override
 	public @NotNull List<SlotText> getText(@Nullable Slot slot, @NotNull ItemStack stack, int slotId) {
 		switch (stack.getSkyblockId()) {
-			case "NEW_BOTTLE_OF_JYRRE", "DARK_CACAO_TRUFFLE", "DISCRITE" -> {
+			case "NEW_BOTTLE_OF_JYRRE", "DARK_CACAO_TRUFFLE", "DISCRITE", "MOBY_DUCK" -> {
 				return actualLogic(stack, "Current Bonus: ");
 			}
 			case "TRAINING_WEIGHTS" -> {


### PR DESCRIPTION
This is a new evolving item added in the Backwater Bayou alpha test, granting fishing wisdom. Unlike other evolving items, it can only be consumed for its permanent once as opposed to five times.